### PR TITLE
Fix: Properly revert malicious typo commit

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -25,7 +25,7 @@
         app:layout_constraintBottom_toTopOf="@id/myTextView"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        android:text="Push Meee"
+        android:text="Push Me"
         />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This PR demonstrates the proper way to undo a malicious commit that added typos.

## What was done:
1. Identified the malicious commit `e8539cb` with message "Push Meee" that changed "Push Me" to "Push Meee"
2. Used `git revert` to properly undo the malicious commit
3. This creates a clean history showing the revert operation

## Changes:
- Reverted commit e8539cb that maliciously added typos
- The button text is now correctly "Push Me" instead of "Push Meee"

## Technical approach:
- Used `git revert HEAD` to create a proper revert commit
- This maintains git history while undoing the malicious changes
- Force pushed to update the fork with the corrected history